### PR TITLE
Add Method PATCH to be able to send json payload

### DIFF
--- a/src/HttpClient/Guzzle.php
+++ b/src/HttpClient/Guzzle.php
@@ -134,6 +134,7 @@ class Guzzle implements HttpClientInterface
                     ]);
                     break;
                 case 'PUT':
+                case 'PATCH':
                 case 'POST':
                     $body_type = $multipart ? 'multipart' : 'form_params';
 


### PR DESCRIPTION


Cheers!

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | x

Hi there, I'm making this pull request because one of my providers are using a PATCH method request and the body params must be a json payload instead of an array. I saw that the Curl file already has the PATCH implementation but not on Guzzle.
